### PR TITLE
fix: handle null/undefined in encoder to prevent scraper crash

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -1,4 +1,5 @@
-export default (toEncode: string): string => {
+export default (toEncode: string | null | undefined): string => {
+  if (toEncode == null) return "";
   return toEncode
     .replace(new RegExp("&", "g"), "&amp;")
     .replace(new RegExp("<", "g"), "&lt;")


### PR DESCRIPTION
## Summary
- `encoder.ts` was crashing with `TypeError: Cannot read properties of null (reading 'replace')` when the scraper returned `null` for fields like `permalink`
- Added `if (toEncode == null) return ""` guard so the encoder handles null/undefined values gracefully

## Test plan
- [x] Verify that `/wotd` works without errors after the fix
- [x] Confirm that without the fix the command crashes (verified locally)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)