### PR TITLE
fix: resolve /stats crashes (moment import + missing stats file)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,3 @@
-import * as os from "os";
-import * as path from "path";
-
-function expandPath(p: string): string {
-  return p.startsWith("~") ? path.join(os.homedir(), p.slice(1)) : p;
-}
-
 export const botToken = process.env.BOT_TOKEN as string;
 export const botUsername = process.env.BOT_USERNAME;
 export const logChatId = process.env.LOG_CHAT_ID;
@@ -14,7 +7,7 @@ export const channelPostTime = process.env.CHANNEL_POST_TIME;
 export const wotdAnnouncementTime = process.env.WOTD_ANNOUNCEMENT_TIME;
 export const channelId = process.env.CHANNEL_ID;
 export const channelLink = process.env.CHANNEL_LINK;
-export const dataPath = expandPath(process.env.DATA_PATH ?? "./data/");
+export const dataPath = process.env.DATA_PATH ?? "./data/";
 export const maxChannelDefs = parseInt(process.env.MAX_CHANNEL_DEFS ?? "10");
 export const messageCharacterLimit = parseInt(
   process.env.MESSAGE_CHARACTER_LIMIT ?? "4096",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,10 @@
+import * as os from "os";
+import * as path from "path";
+
+function expandPath(p: string): string {
+  return p.startsWith("~") ? path.join(os.homedir(), p.slice(1)) : p;
+}
+
 export const botToken = process.env.BOT_TOKEN as string;
 export const botUsername = process.env.BOT_USERNAME;
 export const logChatId = process.env.LOG_CHAT_ID;
@@ -7,7 +14,7 @@ export const channelPostTime = process.env.CHANNEL_POST_TIME;
 export const wotdAnnouncementTime = process.env.WOTD_ANNOUNCEMENT_TIME;
 export const channelId = process.env.CHANNEL_ID;
 export const channelLink = process.env.CHANNEL_LINK;
-export const dataPath = process.env.DATA_PATH ?? "./data/";
+export const dataPath = expandPath(process.env.DATA_PATH ?? "./data/");
 export const maxChannelDefs = parseInt(process.env.MAX_CHANNEL_DEFS ?? "10");
 export const messageCharacterLimit = parseInt(
   process.env.MESSAGE_CHARACTER_LIMIT ?? "4096",

--- a/src/storage/stats.ts
+++ b/src/storage/stats.ts
@@ -64,7 +64,13 @@ export async function getAllStats(date: moment.Moment) {
 
 export async function getStatsFrom(momentDay: moment.Moment) {
   const todayFileName = getFileNameOfDate(momentDay);
-  const todayStats: IStatsData[] = await jsonfile.readFile(todayFileName);
+  let todayStats: IStatsData[];
+  try {
+    await fs.promises.access(todayFileName);
+    todayStats = await jsonfile.readFile(todayFileName);
+  } catch (_) {
+    todayStats = [];
+  }
   const todayInteractionsDuplicated = flatten(
     todayStats.map((ts) => ts.interactions),
   );

--- a/src/ud-bot.ts
+++ b/src/ud-bot.ts
@@ -2,7 +2,7 @@ import * as TelegramBot from "node-telegram-bot-api";
 import * as format from "string-template";
 import { scheduleJob } from "node-schedule";
 import YAML from "yamljs";
-import moment from "moment";
+import * as moment from "moment";
 
 import UrbanApi from "./urban-api";
 import templates from "./templates";


### PR DESCRIPTION
## Summary

Two bugs that caused `/stats` to crash:

**1. `TypeError: moment is not a function` on every `/stats` call**
- `import moment from "moment"` (default import) emits `moment_1.default(...)` at runtime
- Without `esModuleInterop`, moment's CJS export has no `.default` property
- Switched to `import * as moment from "moment"`, consistent with `src/storage/stats.ts`

**2. `ENOENT` crash when no stats have been recorded yet for a date**
- `getStatsFrom` called `jsonfile.readFile` directly with no existence check
- When the stats folder is empty (e.g. fresh deploy), `/stats` would throw
- Added the same `access` + try/catch pattern already used in `addStats`, returning empty stats instead

## Test plan

- [ ] Run `/stats` on a day with no recorded interactions — should return zero stats, not crash
- [ ] Run `/stats` on a day with recorded interactions — should return correct counts
- [ ] Run `/stats YYYY-MM-DD` with a valid date
- [ ] Run `/stats` with an invalid date — error message should still show

🤖 Generated with [Claude Code](https://claude.com/claude-code)