### PR TITLE
feat: send startup message to log chat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ logger.log("Starting...");
 const bot = new UdBot(botToken, { polling: true });
 
 const start = async (): Promise<void> => {
+  await bot.logToTelegram("Bot started");
   await udChannel.init();
 };
 


### PR DESCRIPTION
## Summary

- Calls `bot.logToTelegram("Bot started")` in the `start()` function before `udChannel.init()`
- Only fires when `LOG_CHAT_ID` is configured (guarded inside `logToTelegram`)
- Makes it easy to know when the bot has restarted from the Telegram log chat

## Test plan

- [ ] Set `LOG_CHAT_ID` and `BOT_TOKEN` in `.env`
- [ ] Run `npm run dev` and confirm a "Bot started" message appears in the log chat
- [ ] Confirm no message is sent when `LOG_CHAT_ID` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)