### PR TITLE
fix: remove --env-file from start scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "pretty": "prettier --write .",
-    "start": "node --env-file=.env dist/index.js",
-    "start:inspect": "node --env-file=.env --inspect=0.0.0.0:6068 dist/index.js",
+    "start": "node dist/index.js",
+    "start:inspect": "node --inspect=0.0.0.0:6068 dist/index.js",
     "prepare": "[ -d node_modules/husky ] && husky install || true"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- `npm start` corría `node --env-file=.env dist/index.js`, que buscaba `.env` en el directorio del repo
- En producción (warden + systemd) ese `.env` no existe — las variables de entorno las inyecta systemd via `EnvironmentFile=secrets.env`
- Esto causaba que el servicio crasheara en bucle con `node: .env: not found`

## Cambios

- Eliminado `--env-file=.env` de `start` y `start:inspect`
- `npm run dev` (nodemon) no se ve afectado y sigue cargando `.env` localmente

## Test plan

- [ ] Verificar en la Pi que el servicio arranca correctamente tras el redeploy de warden
- [ ] Comprobar que `npm run dev` sigue funcionando en local con `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)