### PR TITLE
chore: remove thumbs up/down votes

### DIFF
--- a/resources/templates/definition.txt
+++ b/resources/templates/definition.txt
@@ -6,4 +6,4 @@
 📌 <b>Examples</b>
 {formattedExample}
 
-{thumbsUp}👍     {thumbsDown}👎     <a href="{permalink}">Source</a>
+<a href="{permalink}">Source</a>

--- a/src/features/definitions/definition.ts
+++ b/src/features/definitions/definition.ts
@@ -8,8 +8,6 @@ export class UdDefinition {
   definition: string;
   formattedDefinition: string;
   permalink: string;
-  thumbsUp: number;
-  thumbsDown: number;
   author: string;
   word: string;
   example: string;
@@ -21,8 +19,6 @@ export class UdDefinition {
     this.defId = jsonObject.defid;
     this.definition = encode(jsonObject.definition);
     this.permalink = encode(jsonObject.permalink);
-    this.thumbsUp = jsonObject.thumbs_up;
-    this.thumbsDown = jsonObject.thumbs_down;
     this.author = encode(jsonObject.author);
     this.word = encode(jsonObject.word);
     this.example = encode(jsonObject.example);

--- a/src/features/definitions/scraper.ts
+++ b/src/features/definitions/scraper.ts
@@ -11,8 +11,6 @@ function scrapeDefinition(htmlElement: cheerio.Element): UdDefinition {
     definition: replaceLinks($(htmlElement).find(".meaning")),
     example: replaceLinks($(htmlElement).find(".example")),
     permalink: permalink != null ? `${cleanUrl}${permalink}` : null,
-    thumbs_up: parseInt($(htmlElement).find("a.up .count").text()),
-    thumbs_down: parseInt($(htmlElement).find("a.down .count").text()),
     author: $(htmlElement).find(".contributor a").text(),
     word: $(htmlElement).find(".word").text(),
     gif: $(htmlElement).find(".gif img").attr("src"),


### PR DESCRIPTION
## Summary

- Urban Dictionary's API and website no longer return vote counts — all values come back as `0`
- Removed `thumbsUp` / `thumbsDown` fields from `UdDefinition`
- Removed vote selectors from the scraper
- Removed the votes line from `definition.txt` template

## Test plan

- [ ] `npm test` passes (39 tests)
- [ ] `npm run build` compiles cleanly
- [ ] Definition messages no longer show `0👍 0👎`

🤖 Generated with [Claude Code](https://claude.com/claude-code)