### PR TITLE
refactor: simplify message format and link word to permalink

### DIFF
--- a/resources/templates/channel-post.txt
+++ b/resources/templates/channel-post.txt
@@ -1,9 +1,9 @@
-<b>{word}</b> by <a href="http://www.urbandictionary.com/author.php?author={author}">{author}</a>
+<a href="{permalink}"><b>{word}</b></a> by <a href="http://www.urbandictionary.com/author.php?author={author}">{author}</a>
 
-ℹ️ <b>Description</b>
+ℹ️
 {formattedDefinition}
 
-📌 <b>Examples</b>
+📌
 {formattedExample}
 
-#WordOfTheDay - <a href="{permalink}">Source</a>
+#WordOfTheDay

--- a/resources/templates/definition.txt
+++ b/resources/templates/definition.txt
@@ -1,9 +1,7 @@
-<b>{word}</b> by <a href="http://www.urbandictionary.com/author.php?author={author}">{author}</a>
+<a href="{permalink}"><b>{word}</b></a> by <a href="http://www.urbandictionary.com/author.php?author={author}">{author}</a>
 
-ℹ️ <b>Description</b>
+ℹ️
 {formattedDefinition}
 
-📌 <b>Examples</b>
+📌
 {formattedExample}
-
-<a href="{permalink}">Source</a>

--- a/src/features/definitions/keyboards.ts
+++ b/src/features/definitions/keyboards.ts
@@ -18,11 +18,8 @@ export default {
     if (buttonResponse) {
       const { definitions: defs, position: pos, term } = buttonResponse;
 
-      function callbackData(position: number): string {
-        return defs.length > 1
-          ? formatter.compress(`${term}_${position}`)
-          : "ignore";
-      }
+      const callbackData = (position: number): string =>
+        defs.length > 1 ? formatter.compress(`${term}_${position}`) : "ignore";
 
       const navigationButtons = [
         {


### PR DESCRIPTION
## Summary

- Word title is now a clickable link to the UD permalink (replaces the "Source" link at the bottom)
- Section headers ("Description" / "Examples" in bold) replaced with emoji-only markers (ℹ️ / 📌) to reduce visual noise
- Fixed a pre-existing lint error in `keyboards.ts` (`function` declaration inside `if` → arrow function)

## Test plan

- [ ] Send a term to the bot and verify the word title is a clickable link
- [ ] Verify ℹ️ and 📌 markers appear before each section without text labels
- [ ] Verify WOTD channel post has the same format and `#WordOfTheDay` tag is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)