### PR TITLE
refactor: consolidate to a single definition template

### DIFF
--- a/resources/templates/channel-post.txt
+++ b/resources/templates/channel-post.txt
@@ -1,9 +1,0 @@
-<a href="{permalink}"><b>{word}</b></a> by <a href="http://www.urbandictionary.com/author.php?author={author}">{author}</a>
-
-ℹ️
-{formattedDefinition}
-
-📌
-{formattedExample}
-
-#WordOfTheDay

--- a/resources/templates/inline-definition.txt
+++ b/resources/templates/inline-definition.txt
@@ -1,5 +1,0 @@
-️ℹ️ <b>Definition of {word}</b>
-{formattedDefinition}
-
-📌 <b>Examples</b>
-{formattedExample}

--- a/src/features/channel/sender.ts
+++ b/src/features/channel/sender.ts
@@ -25,7 +25,7 @@ export async function sendWord(
 
   const msgOpts = { parse_mode: "HTML" as const, disable_web_page_preview: true };
   const promises: Array<Promise<unknown>> = [
-    client.sendMessage(chatId, templates.channelPost(defToSend), msgOpts),
+    client.sendMessage(chatId, templates.definition(defToSend) + "\n\n#WordOfTheDay", msgOpts),
   ];
 
   if (saveWotd) {

--- a/src/features/definitions/inline-results.ts
+++ b/src/features/definitions/inline-results.ts
@@ -1,31 +1,7 @@
 import type { InlineQueryResultArticle } from "../../shared/telegram/types";
 import type { UdDefinition } from "./definition";
-import templates from "./templates";
+import { buildDefinitionText } from "./templates";
 import keyboards from "./keyboards";
-import { truncateHtml } from "./formatter";
-import { messageCharacterLimit } from "../../config";
-
-const TRUNCATION_MARGIN = 100; // safety buffer + room for the "Read more" suffix
-
-export function buildMessageText(definition: UdDefinition): string {
-  const full = templates.definition(definition);
-  if (full.length <= messageCharacterLimit) return full;
-
-  const readMore = ` <a href="${definition.permalink}">Read more</a>`;
-  const shell = templates.definition({ ...definition, formattedDefinition: "", formattedExample: "" });
-  const available = messageCharacterLimit - shell.length - TRUNCATION_MARGIN;
-  const half = Math.floor(available / 2);
-
-  // Each field gets the space the other doesn't use, guaranteed at least half
-  const definitionBudget = available - Math.min(definition.formattedExample.length, half);
-  const exampleBudget    = available - Math.min(definition.formattedDefinition.length, half);
-
-  return templates.definition({
-    ...definition,
-    formattedDefinition: truncateHtml(definition.formattedDefinition, definitionBudget, `...${readMore}`),
-    formattedExample: truncateHtml(definition.formattedExample, exampleBudget, `...${readMore}`),
-  });
-}
 
 export default {
   getResults(definitions: UdDefinition[]): InlineQueryResultArticle[] {
@@ -36,7 +12,7 @@ export default {
       description: definition.definition,
       reply_markup: keyboards.inlineKeyboardResponse(definition.word),
       input_message_content: {
-        message_text: buildMessageText(definition),
+        message_text: buildDefinitionText(definition),
         parse_mode: "HTML" as const,
         disable_web_page_preview: true,
       },

--- a/src/features/definitions/inline-results.ts
+++ b/src/features/definitions/inline-results.ts
@@ -1,21 +1,18 @@
 import type { InlineQueryResultArticle } from "../../shared/telegram/types";
 import type { UdDefinition } from "./definition";
+import templates from "./templates";
 import keyboards from "./keyboards";
 import { truncateHtml } from "./formatter";
 import { messageCharacterLimit } from "../../config";
 
 const TRUNCATION_MARGIN = 100; // safety buffer + room for the "Read more" suffix
 
-function renderMessage(word: string, definition: string, example: string): string {
-  return `️ℹ️ <b>Definition of ${word}</b>\n${definition}\n\n📌 <b>Examples</b>\n${example}\n`;
-}
-
 export function buildMessageText(definition: UdDefinition): string {
-  const full = renderMessage(definition.word, definition.formattedDefinition, definition.formattedExample);
+  const full = templates.definition(definition);
   if (full.length <= messageCharacterLimit) return full;
 
   const readMore = ` <a href="${definition.permalink}">Read more</a>`;
-  const shell = renderMessage(definition.word, "", "");
+  const shell = templates.definition({ ...definition, formattedDefinition: "", formattedExample: "" });
   const available = messageCharacterLimit - shell.length - TRUNCATION_MARGIN;
   const half = Math.floor(available / 2);
 
@@ -23,11 +20,11 @@ export function buildMessageText(definition: UdDefinition): string {
   const definitionBudget = available - Math.min(definition.formattedExample.length, half);
   const exampleBudget    = available - Math.min(definition.formattedDefinition.length, half);
 
-  return renderMessage(
-    definition.word,
-    truncateHtml(definition.formattedDefinition, definitionBudget, `...${readMore}`),
-    truncateHtml(definition.formattedExample, exampleBudget, `...${readMore}`),
-  );
+  return templates.definition({
+    ...definition,
+    formattedDefinition: truncateHtml(definition.formattedDefinition, definitionBudget, `...${readMore}`),
+    formattedExample: truncateHtml(definition.formattedExample, exampleBudget, `...${readMore}`),
+  });
 }
 
 export default {

--- a/src/features/definitions/templates.test.ts
+++ b/src/features/definitions/templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildMessageText } from "./inline-results";
+import { buildDefinitionText } from "./templates";
 import type { UdDefinition } from "./definition";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -36,14 +36,14 @@ const TELEGRAM_LIMIT = 4096;
 
 describe("buildMessageText", () => {
   it("returns the full message when both fields fit", () => {
-    const result = buildMessageText(makeDefinition());
+    const result = buildDefinitionText(makeDefinition());
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
     expect(result).not.toContain("Read more");
   });
 
   it("does not truncate when a long definition still fits within the total limit", () => {
     // ~1500 chars def + short example — well under 4096
-    const result = buildMessageText(makeDefinition({ formattedDefinition: repeat("word ", 300) }));
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: repeat("word ", 300) }));
     expect(result).not.toContain("Read more");
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
   });
@@ -51,7 +51,7 @@ describe("buildMessageText", () => {
   it("truncates only the definition when it alone pushes the total over the limit", () => {
     const longDefinition = repeat("word ", 900); // ~4500 chars
     const shortExample = "<i>short</i>";
-    const result = buildMessageText(makeDefinition({ formattedDefinition: longDefinition, formattedExample: shortExample }));
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: longDefinition, formattedExample: shortExample }));
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
     expect(result).toContain("Read more");
     // The short example must appear verbatim — it was not truncated
@@ -61,7 +61,7 @@ describe("buildMessageText", () => {
   it("truncates only the example when it alone pushes the total over the limit", () => {
     const shortDefinition = "a short definition";
     const longExample = `<i>${repeat("word ", 900)}</i>`;
-    const result = buildMessageText(makeDefinition({ formattedDefinition: shortDefinition, formattedExample: longExample }));
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: shortDefinition, formattedExample: longExample }));
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
     expect(result).toContain("Read more");
     // The short definition must appear verbatim — it was not truncated
@@ -71,7 +71,7 @@ describe("buildMessageText", () => {
   it("truncates both fields when both are very long", () => {
     const longDefinition = repeat("word ", 1000);
     const longExample = `<i>${repeat("word ", 1000)}</i>`;
-    const result = buildMessageText(makeDefinition({ formattedDefinition: longDefinition, formattedExample: longExample }));
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: longDefinition, formattedExample: longExample }));
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
     expect(result.split("Read more").length - 1).toBe(2);
   });
@@ -79,7 +79,7 @@ describe("buildMessageText", () => {
   it("never exceeds TELEGRAM_LIMIT even with maximum-length inputs", () => {
     const maxDefinition = repeat("a ", 3000);
     const maxExample = `<i>${repeat("b ", 3000)}</i>`;
-    const result = buildMessageText(
+    const result = buildDefinitionText(
       makeDefinition({ word: repeat("w", 50), formattedDefinition: maxDefinition, formattedExample: maxExample }),
     );
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
@@ -88,7 +88,7 @@ describe("buildMessageText", () => {
   it("does not produce a broken HTML tag when truncation falls mid-tag", () => {
     const prefix = repeat("word ", 390);
     const definitionWithTag = `${prefix}<a href="https://urbandictionary.com/define.php?term=something-very-long">linked word</a>`;
-    const result = buildMessageText(makeDefinition({ formattedDefinition: definitionWithTag }));
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: definitionWithTag }));
     expect(result).not.toMatch(/<[^>]*$/m);
     expect(result.length).toBeLessThanOrEqual(TELEGRAM_LIMIT);
   });
@@ -96,7 +96,7 @@ describe("buildMessageText", () => {
   it("includes the permalink in the Read more link", () => {
     const permalink = "https://www.urbandictionary.com/define.php?term=bong";
     const longDefinition = repeat("word ", 1000);
-    const result = buildMessageText(makeDefinition({ formattedDefinition: longDefinition, permalink }));
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: longDefinition, permalink }));
     expect(result).toContain(`href="${permalink}"`);
   });
 });

--- a/src/features/definitions/templates.ts
+++ b/src/features/definitions/templates.ts
@@ -2,20 +2,10 @@ import * as Fs from "fs";
 import { UdDefinition } from "./definition";
 
 const definitionTemplate = readTemplate("definition");
-const channelPostTemplate = readTemplate("channel-post");
-const inlineDefinitionTemplate = readTemplate("inline-definition");
 
 export default {
   definition(data: Pick<UdDefinition, "permalink" | "word" | "author" | "formattedDefinition" | "formattedExample">): string {
     return format(definitionTemplate, data);
-  },
-
-  channelPost(data: UdDefinition): string {
-    return format(channelPostTemplate, data);
-  },
-
-  inlineDefinition(data: UdDefinition): string {
-    return format(inlineDefinitionTemplate, data);
   },
 };
 

--- a/src/features/definitions/templates.ts
+++ b/src/features/definitions/templates.ts
@@ -1,5 +1,9 @@
 import * as Fs from "fs";
 import { UdDefinition } from "./definition";
+import { truncateHtml } from "./formatter";
+import { messageCharacterLimit } from "../../config";
+
+const TRUNCATION_MARGIN = 100; // safety buffer + room for the "Read more" suffix
 
 const definitionTemplate = readTemplate("definition");
 
@@ -8,6 +12,26 @@ export default {
     return format(definitionTemplate, data);
   },
 };
+
+export function buildDefinitionText(definition: UdDefinition): string {
+  const full = format(definitionTemplate, definition);
+  if (full.length <= messageCharacterLimit) return full;
+
+  const readMore = ` <a href="${definition.permalink}">Read more</a>`;
+  const shell = format(definitionTemplate, { ...definition, formattedDefinition: "", formattedExample: "" });
+  const available = messageCharacterLimit - shell.length - TRUNCATION_MARGIN;
+  const half = Math.floor(available / 2);
+
+  // Each field gets the space the other doesn't use, guaranteed at least half
+  const definitionBudget = available - Math.min(definition.formattedExample.length, half);
+  const exampleBudget    = available - Math.min(definition.formattedDefinition.length, half);
+
+  return format(definitionTemplate, {
+    ...definition,
+    formattedDefinition: truncateHtml(definition.formattedDefinition, definitionBudget, `...${readMore}`),
+    formattedExample: truncateHtml(definition.formattedExample, exampleBudget, `...${readMore}`),
+  });
+}
 
 function readTemplate(name: string): string {
   return Fs.readFileSync(`./resources/templates/${name}.txt`, "utf8").toString();

--- a/src/ud-bot.ts
+++ b/src/ud-bot.ts
@@ -1,10 +1,10 @@
 import { Cron } from "croner";
 
 import UrbanApi from "./features/definitions/api";
-import templates from "./features/definitions/templates";
+import { buildDefinitionText } from "./features/definitions/templates";
 import keyboards from "./features/definitions/keyboards";
 import inlineResults from "./features/definitions/inline-results";
-import formatter, { truncateHtml } from "./features/definitions/formatter";
+import formatter from "./features/definitions/formatter";
 import encode from "./features/definitions/encoder";
 import { UdDefinition } from "./features/definitions/definition";
 import { isArabic } from "./util";
@@ -27,14 +27,11 @@ import {
   channelId,
   logChatId,
   statsPostTime,
-  messageCharacterLimit,
 } from "./config";
 import { TelegramClient } from "./shared/telegram/client";
 import type { SendMessageOptions, EditMessageTextOptions } from "./shared/telegram/client";
 import type { Message, Chat, CallbackQuery, InlineQuery, ChosenInlineResult } from "./shared/telegram/types";
 import type { UpdateHandlers } from "./shared/telegram/router";
-
-const DEFINITION_TRUNCATION_MARGIN = 100; // safety buffer + room for the "Read more" suffix
 
 export class UdBot {
   constructor(private client: TelegramClient) {
@@ -218,23 +215,7 @@ export class UdBot {
   }
 
   buildDefinition(definition: UdDefinition): string {
-    const full = templates.definition(definition);
-    if (full.length <= messageCharacterLimit) return full;
-
-    const readMore = ` <a href="${definition.permalink}">Read more</a>`;
-    const shell = templates.definition({ ...definition, formattedDefinition: "", formattedExample: "" });
-    const available = messageCharacterLimit - shell.length - DEFINITION_TRUNCATION_MARGIN;
-    const half = Math.floor(available / 2);
-
-    // Each field gets the space the other doesn't use, guaranteed at least half
-    const definitionBudget = available - Math.min(definition.formattedExample.length, half);
-    const exampleBudget    = available - Math.min(definition.formattedDefinition.length, half);
-
-    return templates.definition({
-      ...definition,
-      formattedDefinition: truncateHtml(definition.formattedDefinition, definitionBudget, `...${readMore}`),
-      formattedExample: truncateHtml(definition.formattedExample, exampleBudget, `...${readMore}`),
-    });
+    return buildDefinitionText(definition);
   }
 
   async sendDefinition(


### PR DESCRIPTION
## Summary

- `inline-definition.txt` and `channel-post.txt` were near-identical copies of `definition.txt` with minor differences (different header for inline, `#WordOfTheDay` suffix for channel)
- Remove both redundant files and use `definition.txt` everywhere
- Inline results now share the same format as direct messages (author + permalink in header)
- Channel sender appends `#WordOfTheDay` in code instead of a separate template file
- Extract `buildDefinitionText` to `templates.ts` — both `buildDefinition` and inline results were identical after the consolidation, so the logic now lives in one place
- `templates.ts` now exports a single `definition()` method and `buildDefinitionText()`

## Test plan
- [x] All 54 tests pass (`npm test`)
- [x] `npm run lint` and `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)