### PR TITLE
feat: apply separate 1200-char limit for inline query messages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ const env = z
     DATA_PATH: z.string().default("./data/"),
     MAX_CHANNEL_DEFS: z.coerce.number().int().positive().default(10),
     MESSAGE_CHARACTER_LIMIT: z.coerce.number().int().positive().default(4096),
+    INLINE_CHARACTER_LIMIT: z.coerce.number().int().positive().default(1200),
   })
   .parse(process.env);
 
@@ -29,3 +30,4 @@ export const channelLink = env.CHANNEL_LINK;
 export const dataPath = env.DATA_PATH;
 export const maxChannelDefs = env.MAX_CHANNEL_DEFS;
 export const messageCharacterLimit = env.MESSAGE_CHARACTER_LIMIT;
+export const inlineCharacterLimit = env.INLINE_CHARACTER_LIMIT;

--- a/src/features/definitions/formatter.test.ts
+++ b/src/features/definitions/formatter.test.ts
@@ -53,6 +53,21 @@ describe("formatter", () => {
       expect(truncateHtml(text, 50, "...")).not.toMatch(/<[^>]*$/);
     });
 
+    it("closes unclosed tags when truncation cuts before the closing tag", () => {
+      const text = '<i>word word word word word word word word word word word word word word</i>';
+      const result = truncateHtml(text, 30, "...");
+      // The <i> tag must be closed even though the closing </i> was cut off
+      expect(result).toContain("</i>");
+      expect(result).not.toMatch(/<[^>]*$/);
+    });
+
+    it("closes an unclosed <a> tag when truncation cuts inside its content", () => {
+      // Opening tag (30 chars) + "before " (7) = 37 chars; maxLength 55 ensures it fits before the cut
+      const text = 'before <a href="https://example.com">linked word here and more</a> after';
+      const result = truncateHtml(text, 55, "...");
+      expect(result).toContain("</a>");
+    });
+
     it("handles text with no spaces gracefully", () => {
       const result = truncateHtml("x".repeat(100), 20, "...");
       expect(result.length).toBeLessThanOrEqual(20);

--- a/src/features/definitions/formatter.ts
+++ b/src/features/definitions/formatter.ts
@@ -63,5 +63,28 @@ export function truncateHtml(text: string, maxLength: number, suffix: string): s
   // Drop any incomplete HTML tag (e.g. a "<a href=" cut mid-attribute)
   sliced = sliced.replace(/<[^>]*$/, "");
 
+  // Close any tags that were opened but not closed before the cut point
+  sliced = closeUnclosedTags(sliced);
+
   return sliced.trimEnd() + suffix;
+}
+
+function closeUnclosedTags(html: string): string {
+  const openTags: string[] = [];
+  const tagPattern = /<\/?([a-zA-Z]+)[^>]*>/g;
+  let match;
+
+  while ((match = tagPattern.exec(html)) !== null) {
+    const isClosing = match[0].startsWith("</");
+    const tagName = match[1].toLowerCase();
+
+    if (isClosing) {
+      const lastOpen = openTags.lastIndexOf(tagName);
+      if (lastOpen !== -1) openTags.splice(lastOpen, 1);
+    } else {
+      openTags.push(tagName);
+    }
+  }
+
+  return html + openTags.reverse().map((tag) => `</${tag}>`).join("");
 }

--- a/src/features/definitions/inline-results.ts
+++ b/src/features/definitions/inline-results.ts
@@ -2,6 +2,7 @@ import type { InlineQueryResultArticle } from "../../shared/telegram/types";
 import type { UdDefinition } from "./definition";
 import { buildDefinitionText } from "./templates";
 import keyboards from "./keyboards";
+import { inlineCharacterLimit } from "../../config";
 
 export default {
   getResults(definitions: UdDefinition[]): InlineQueryResultArticle[] {
@@ -12,7 +13,7 @@ export default {
       description: definition.definition,
       reply_markup: keyboards.inlineKeyboardResponse(definition.word),
       input_message_content: {
-        message_text: buildDefinitionText(definition),
+        message_text: buildDefinitionText(definition, inlineCharacterLimit),
         parse_mode: "HTML" as const,
         disable_web_page_preview: true,
       },

--- a/src/features/definitions/templates.test.ts
+++ b/src/features/definitions/templates.test.ts
@@ -99,4 +99,11 @@ describe("buildMessageText", () => {
     const result = buildDefinitionText(makeDefinition({ formattedDefinition: longDefinition, permalink }));
     expect(result).toContain(`href="${permalink}"`);
   });
+
+  it("respects a custom limit passed as second argument", () => {
+    const longDefinition = repeat("word ", 300); // ~1500 chars — under 4096 but over 1200
+    const result = buildDefinitionText(makeDefinition({ formattedDefinition: longDefinition }), 1200);
+    expect(result.length).toBeLessThanOrEqual(1200);
+    expect(result).toContain("Read more");
+  });
 });

--- a/src/features/definitions/templates.ts
+++ b/src/features/definitions/templates.ts
@@ -13,13 +13,13 @@ export default {
   },
 };
 
-export function buildDefinitionText(definition: UdDefinition): string {
+export function buildDefinitionText(definition: UdDefinition, limit = messageCharacterLimit): string {
   const full = format(definitionTemplate, definition);
-  if (full.length <= messageCharacterLimit) return full;
+  if (full.length <= limit) return full;
 
   const readMore = ` <a href="${definition.permalink}">Read more</a>`;
   const shell = format(definitionTemplate, { ...definition, formattedDefinition: "", formattedExample: "" });
-  const available = messageCharacterLimit - shell.length - TRUNCATION_MARGIN;
+  const available = limit - shell.length - TRUNCATION_MARGIN;
   const half = Math.floor(available / 2);
 
   // Each field gets the space the other doesn't use, guaranteed at least half


### PR DESCRIPTION
## Summary

- Adds `INLINE_CHARACTER_LIMIT` env var (default: `1200`) applied only to inline query results — avoids wall-of-text spam when definitions are shared in large groups
- `buildDefinitionText` now accepts an optional `limit` parameter (defaults to `MESSAGE_CHARACTER_LIMIT`) so the regular message flow is unchanged
- Fixes a pre-existing bug in `truncateHtml`: when the cut point fell inside an open HTML tag (e.g. `<a>`, `<i>`), the tag was left unclosed and Telegram rejected the message with a 400 — this was triggered by the tighter limit; `closeUnclosedTags` now closes any open tags after truncation

## Test plan

- [ ] Search "hipster" (long definition with linked words) via inline mode — result should appear without error
- [ ] Click "More info" button on inline result — no error
- [ ] Send inline result to a group — message should be ≤ ~1200 chars with a "Read more" link
- [ ] Direct message search still shows the full definition (up to 4096 chars)
- [ ] Set `INLINE_CHARACTER_LIMIT=2000` in `.env` and verify the override is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)