### PR TITLE
refactor: clean up definition display — strip word links and remove author

### DIFF
--- a/resources/templates/definition.txt
+++ b/resources/templates/definition.txt
@@ -1,4 +1,4 @@
-<a href="{permalink}"><b>{word}</b></a> by <a href="http://www.urbandictionary.com/author.php?author={author}">{author}</a>
+<a href="{permalink}"><b>{word}</b></a>
 
 ℹ️
 {formattedDefinition}

--- a/src/features/definitions/definition.ts
+++ b/src/features/definitions/definition.ts
@@ -24,24 +24,11 @@ export class UdDefinition {
     this.example = encode(jsonObject.example);
     this.gif = jsonObject.gif;
 
-    this.formattedDefinition = this.formatLinks(this.definition);
-    this.formattedExample = formatter.italic(
-      this.formatLinks(
-        this.example,
-        formatter.ITALIC_CLOSE_TAG,
-        formatter.ITALIC_OPEN_TAG,
-      ),
-    );
+    this.formattedDefinition = this.stripBrackets(this.definition);
+    this.formattedExample = formatter.italic(this.stripBrackets(this.example));
   }
 
-  formatLinks(text: string, prefix?: string, suffix?: string): string {
-    return text.replace(wordLinkRegex, (match) => {
-      const word = match.slice(1, -1);
-      return (
-        (prefix ?? "") +
-        formatter.link(word, formatter.startUrl(word)) +
-        (suffix ?? "")
-      );
-    });
+  stripBrackets(text: string): string {
+    return text.replace(wordLinkRegex, (match) => match.slice(1, -1));
   }
 }

--- a/src/features/definitions/definition.ts
+++ b/src/features/definitions/definition.ts
@@ -8,7 +8,6 @@ export class UdDefinition {
   definition: string;
   formattedDefinition: string;
   permalink: string;
-  author: string;
   word: string;
   example: string;
   formattedExample: string;
@@ -19,7 +18,6 @@ export class UdDefinition {
     this.defId = jsonObject.defid;
     this.definition = encode(jsonObject.definition);
     this.permalink = encode(jsonObject.permalink);
-    this.author = encode(jsonObject.author);
     this.word = encode(jsonObject.word);
     this.example = encode(jsonObject.example);
     this.gif = jsonObject.gif;

--- a/src/features/definitions/inline-results.ts
+++ b/src/features/definitions/inline-results.ts
@@ -10,7 +10,7 @@ export default {
       type: "article",
       title: definition.word,
       id: definition.defId.toString(),
-      description: definition.definition,
+      description: definition.formattedDefinition,
       reply_markup: keyboards.inlineKeyboardResponse(definition.word),
       input_message_content: {
         message_text: buildDefinitionText(definition, inlineCharacterLimit),

--- a/src/features/definitions/scraper.ts
+++ b/src/features/definitions/scraper.ts
@@ -13,7 +13,6 @@ function scrapeDefinition(htmlElement: cheerio.Element): UdDefinition {
     definition: replaceLinks($(htmlElement).find(".meaning")),
     example: replaceLinks($(htmlElement).find(".example")),
     permalink: `${cleanUrl}${permalink}`,
-    author: $(htmlElement).find('a[data-grow-track="ui.click_author"]').text(),
     word: $(htmlElement).find(".word").text(),
     gif: $(htmlElement).find(".gif img").attr("src"),
   };

--- a/src/features/definitions/templates.test.ts
+++ b/src/features/definitions/templates.test.ts
@@ -24,7 +24,6 @@ function makeDefinition(overrides: {
     permalink:
       overrides.permalink ??
       "https://www.urbandictionary.com/define.php?term=test",
-    author: "author",
     gif: undefined,
     stripBrackets: () => "",
   } as unknown as UdDefinition;

--- a/src/features/definitions/templates.test.ts
+++ b/src/features/definitions/templates.test.ts
@@ -26,7 +26,7 @@ function makeDefinition(overrides: {
       "https://www.urbandictionary.com/define.php?term=test",
     author: "author",
     gif: undefined,
-    formatLinks: () => "",
+    stripBrackets: () => "",
   } as unknown as UdDefinition;
 }
 

--- a/src/features/definitions/templates.ts
+++ b/src/features/definitions/templates.ts
@@ -8,7 +8,7 @@ const TRUNCATION_MARGIN = 100; // safety buffer + room for the "Read more" suffi
 const definitionTemplate = readTemplate("definition");
 
 export default {
-  definition(data: Pick<UdDefinition, "permalink" | "word" | "author" | "formattedDefinition" | "formattedExample">): string {
+  definition(data: Pick<UdDefinition, "permalink" | "word" | "formattedDefinition" | "formattedExample">): string {
     return format(definitionTemplate, data);
   },
 };


### PR DESCRIPTION
## Summary

- Bracketed words in UD definitions and examples (e.g. `[word]`) were being converted to deep-link anchors (`t.me/bot?start=…`), cluttering the message. Now the brackets are stripped and the plain word is shown.
- Removes author attribution from the definition header.
- Fixes inline query result descriptions, which were using the raw definition field (brackets intact) instead of the already-processed `formattedDefinition`.
- `formatLinks` renamed to `stripBrackets` to reflect the new behaviour.

## Test plan

- [ ] Send a definition with bracketed words via direct message — confirm no links appear in definition or example
- [ ] Trigger an inline query — confirm descriptions show no brackets
- [ ] Confirm author is no longer shown in any definition message
- [ ] `npm test` passes (57 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)