### PR TITLE
feat: restore author attribution without hyperlink

### DIFF
--- a/resources/templates/definition.txt
+++ b/resources/templates/definition.txt
@@ -1,4 +1,4 @@
-<a href="{permalink}"><b>{word}</b></a>
+<a href="{permalink}"><b>{word}</b></a> by <i>{author}</i>
 
 ℹ️
 {formattedDefinition}

--- a/src/features/definitions/definition.ts
+++ b/src/features/definitions/definition.ts
@@ -8,6 +8,7 @@ export class UdDefinition {
   definition: string;
   formattedDefinition: string;
   permalink: string;
+  author: string;
   word: string;
   example: string;
   formattedExample: string;
@@ -18,6 +19,7 @@ export class UdDefinition {
     this.defId = jsonObject.defid;
     this.definition = encode(jsonObject.definition);
     this.permalink = encode(jsonObject.permalink);
+    this.author = encode(jsonObject.author ?? "");
     this.word = encode(jsonObject.word);
     this.example = encode(jsonObject.example);
     this.gif = jsonObject.gif;

--- a/src/features/definitions/scraper.ts
+++ b/src/features/definitions/scraper.ts
@@ -13,6 +13,7 @@ function scrapeDefinition(htmlElement: cheerio.Element): UdDefinition {
     definition: replaceLinks($(htmlElement).find(".meaning")),
     example: replaceLinks($(htmlElement).find(".example")),
     permalink: `${cleanUrl}${permalink}`,
+    author: $(htmlElement).find('a[data-grow-track="ui.click_author"]').text(),
     word: $(htmlElement).find(".word").text(),
     gif: $(htmlElement).find(".gif img").attr("src"),
   };

--- a/src/features/definitions/templates.test.ts
+++ b/src/features/definitions/templates.test.ts
@@ -24,6 +24,7 @@ function makeDefinition(overrides: {
     permalink:
       overrides.permalink ??
       "https://www.urbandictionary.com/define.php?term=test",
+    author: "author",
     gif: undefined,
     stripBrackets: () => "",
   } as unknown as UdDefinition;

--- a/src/features/definitions/templates.ts
+++ b/src/features/definitions/templates.ts
@@ -8,7 +8,7 @@ const TRUNCATION_MARGIN = 100; // safety buffer + room for the "Read more" suffi
 const definitionTemplate = readTemplate("definition");
 
 export default {
-  definition(data: Pick<UdDefinition, "permalink" | "word" | "formattedDefinition" | "formattedExample">): string {
+  definition(data: Pick<UdDefinition, "permalink" | "word" | "author" | "formattedDefinition" | "formattedExample">): string {
     return format(definitionTemplate, data);
   },
 };


### PR DESCRIPTION
## Summary
- Adds back the `author` field to `UdDefinition` and the scraper
- Displays it in the definition template as `by <i>author</i>` (no hyperlink)
- Restores `author` to the `templates.ts` Pick type and test fixture

## Test plan
- [ ] Send a definition query to the bot and verify `by <i>username</i>` appears under the word title
- [ ] Confirm all tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)