### PR TITLE
fix: make error logging resilient to Telegram outages (#56)

### DIFF
--- a/src/shared/telegram/poller.test.ts
+++ b/src/shared/telegram/poller.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Poller, isTransientError } from "./poller";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe("isTransientError", () => {
+  it.each([
+    "getUpdates failed: Bad Gateway",
+    "getUpdates failed: Gateway Timeout",
+    "getUpdates failed: Service Unavailable",
+    "request timed out",
+    "fetch failed",
+    "read ECONNRESET",
+    "connect ECONNREFUSED 1.2.3.4",
+    "getaddrinfo ENOTFOUND api.telegram.org",
+    "getaddrinfo EAI_AGAIN api.telegram.org",
+    "The operation was aborted",
+  ])("classifies %j as transient", (message) => {
+    expect(isTransientError(new Error(message))).toBe(true);
+  });
+
+  it("classifies AbortError / TimeoutError by name", () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    const timeout = new Error("timeout");
+    timeout.name = "TimeoutError";
+    expect(isTransientError(abort)).toBe(true);
+    expect(isTransientError(timeout)).toBe(true);
+  });
+
+  it("does not classify auth/logic errors as transient", () => {
+    expect(isTransientError(new Error("getUpdates failed: Unauthorized"))).toBe(false);
+    expect(isTransientError(new Error("Bad Request: chat not found"))).toBe(false);
+  });
+});
+
+describe("Poller", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delivers updates to onUpdate and advances the offset", async () => {
+    // First call returns one update; subsequent calls never resolve so the
+    // poll loop parks instead of spinning.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            ok: true,
+            result: [{ update_id: 41, message: { text: "hi" } }],
+          }),
+      })
+      .mockReturnValue(new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onUpdate = vi.fn();
+    const onError = vi.fn();
+    const poller = new Poller("token", onUpdate, onError);
+
+    poller.start();
+    await flush();
+    poller.stop();
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      update_id: 41,
+      message: { text: "hi" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+    // offset advanced past update 41
+    expect(fetchMock.mock.calls[1][0]).toContain("offset=42");
+  });
+
+  it("does NOT route transient getUpdates failures through onError", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ ok: false, description: "Bad Gateway" }),
+      })
+      .mockReturnValue(new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onError = vi.fn();
+    const poller = new Poller("token", vi.fn(), onError);
+
+    poller.start();
+    await flush();
+    poller.stop();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("routes non-transient failures through onError", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ ok: false, description: "Unauthorized" }),
+      })
+      .mockReturnValue(new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onError = vi.fn();
+    const poller = new Poller("token", vi.fn(), onError);
+
+    poller.start();
+    await flush();
+    poller.stop();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toContain("Unauthorized");
+  });
+});

--- a/src/shared/telegram/poller.ts
+++ b/src/shared/telegram/poller.ts
@@ -1,8 +1,34 @@
+import logger from "../../logger";
 import type { Update } from "./types";
+
+// Telegram-side outages and network blips are expected and recoverable: the
+// poll loop already backs off and retries, so they should be logged locally
+// rather than routed through a Telegram-dependent error reporter. See issue #56.
+const TRANSIENT_ERROR_PATTERNS = [
+  /Bad Gateway/i,
+  /Gateway Timeout/i,
+  /Service Unavailable/i,
+  /timed? ?out/i,
+  /ECONNRESET/i,
+  /ECONNREFUSED/i,
+  /ENOTFOUND/i,
+  /EAI_AGAIN/i,
+  /network/i,
+  /fetch failed/i,
+  /aborted/i,
+];
+
+export const isTransientError = (error: Error): boolean =>
+  error.name === "AbortError" ||
+  error.name === "TimeoutError" ||
+  TRANSIENT_ERROR_PATTERNS.some((p) => p.test(error.message));
 
 export class Poller {
   private offset = 0;
   private running = false;
+  private backoffMs = 5000;
+  private static readonly MIN_BACKOFF_MS = 5000;
+  private static readonly MAX_BACKOFF_MS = 60000;
 
   constructor(
     private token: string,
@@ -23,15 +49,29 @@ export class Poller {
     while (this.running) {
       try {
         const updates = await this.getUpdates();
+        this.backoffMs = Poller.MIN_BACKOFF_MS;
         for (const update of updates) {
           this.offset = update.update_id + 1;
           this.onUpdate(update);
         }
       } catch (error) {
-        this.onError(error as Error);
-        await new Promise((r) => setTimeout(r, 5000));
+        const err = error as Error;
+        if (isTransientError(err)) {
+          // Recoverable upstream blip: log and keep polling.
+          logger.warn(`getUpdates transient error, retrying: ${err.message}`);
+        } else {
+          this.onError(err);
+        }
+        await new Promise((r) => setTimeout(r, this.nextBackoff()));
       }
     }
+  }
+
+  private nextBackoff(): number {
+    const delay = this.backoffMs;
+    // Exponential backoff with jitter for sustained outages.
+    this.backoffMs = Math.min(this.backoffMs * 2, Poller.MAX_BACKOFF_MS);
+    return delay + Math.floor(Math.random() * 1000);
   }
 
   private async getUpdates(): Promise<Update[]> {

--- a/src/ud-bot.test.ts
+++ b/src/ud-bot.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// logToTelegram must be best-effort: a Telegram outage while *reporting* an
+// error (or logging "Bot started") must never throw, or it would surface as an
+// unhandled rejection and crash-loop the process. See issue #56.
+vi.mock("./config", async () => {
+  const actual = await vi.importActual<typeof import("./config")>("./config");
+  return { ...actual, logChatId: "12345", statsPostTime: undefined };
+});
+
+import { UdBot } from "./ud-bot";
+import type { TelegramClient } from "./shared/telegram/client";
+
+describe("UdBot error logging resilience", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeBot = (sendMessage: TelegramClient["sendMessage"]): UdBot => {
+    const client = { sendMessage } as unknown as TelegramClient;
+    return new UdBot(client);
+  };
+
+  it("logToTelegram does not throw when Telegram is down", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValue(new Error("Telegram API error on sendMessage: Bad Gateway"));
+    const bot = makeBot(sendMessage as unknown as TelegramClient["sendMessage"]);
+
+    await expect(bot.logToTelegram("Bot started")).resolves.toBeUndefined();
+    expect(sendMessage).toHaveBeenCalledWith("12345", "Bot started");
+  });
+
+  it("handleError does not throw when Telegram is down", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValue(new Error("Telegram API error on sendMessage: Gateway Timeout"));
+    const bot = makeBot(sendMessage as unknown as TelegramClient["sendMessage"]);
+
+    await expect(
+      bot.handleError(new Error("getUpdates failed: Bad Gateway")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("logToTelegram sends through the client when Telegram is up", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({});
+    const bot = makeBot(sendMessage as unknown as TelegramClient["sendMessage"]);
+
+    await bot.logToTelegram("hello", { foo: "bar" });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "12345",
+      'hello\n\n{"foo":"bar"}',
+    );
+  });
+});

--- a/src/ud-bot.ts
+++ b/src/ud-bot.ts
@@ -259,12 +259,19 @@ export class UdBot {
   }
 
   async logToTelegram(message: string, moreInfo?: unknown): Promise<void> {
-    if (logChatId != null) {
-      let msg = message;
-      if (moreInfo != null) {
-        msg += "\n\n" + JSON.stringify(moreInfo);
-      }
+    if (logChatId == null) return;
+    let msg = message;
+    if (moreInfo != null) {
+      msg += "\n\n" + JSON.stringify(moreInfo);
+    }
+    // Reporting an error must never become a new error: if Telegram is down,
+    // fall back to the local logger instead of throwing (which would surface
+    // as an unhandled rejection and crash the process). See issue #56.
+    try {
       await this.client.sendMessage(logChatId, msg);
+    } catch (err) {
+      logger.error("Failed to log to Telegram:", err);
+      logger.error("Original message:", msg);
     }
   }
 


### PR DESCRIPTION
## Problem

A transient Telegram API outage (`502 Bad Gateway` / `504 Gateway Timeout`) crash-loops the bot, because **the error-reporting path itself depends on Telegram**. A recoverable upstream blip becomes a process crash, only surviving thanks to systemd auto-restart (observed in production 2026-06-26, restart counter reached 7).

Root cause (per #56):
- `handleError` → `logToTelegram` → `client.sendMessage` **throws** when Telegram is down. The poll loop fires the error callback as a floating promise (`void bot.handleError(...)` in `src/index.ts`), so the rejection is **unhandled** → Node 22 terminates with exit code 1.
- `start()` awaits `logToTelegram("Bot started")` but is invoked as `void start()`, so a Telegram outage at boot crashes immediately → restart loop.

## Solution

- **`logToTelegram` never throws** (`src/ud-bot.ts`): the `sendMessage` call is wrapped in try/catch and falls back to the local logger. Reporting an error can no longer become a new error. This makes both `handleError` and the startup `"Bot started"` log best-effort, so a Telegram outage can't crash-loop the service.
- **Transient `getUpdates` errors are treated as expected** (`src/shared/telegram/poller.ts`): `502`/`504`/`Service Unavailable`/timeouts/network errors (`ECONNRESET`, `ENOTFOUND`, `EAI_AGAIN`, aborts, etc.) are logged locally and the loop keeps polling, instead of being routed through the Telegram-dependent error reporter. Non-transient errors (e.g. `Unauthorized`) still go through `onError`.
- **Backoff with jitter** for sustained outages: exponential backoff from 5s up to 60s with random jitter, reset to 5s on a successful poll.

## Tests

- `src/ud-bot.test.ts`: `logToTelegram` and `handleError` resolve (do not throw) when `sendMessage` rejects; happy path still sends through the client.
- `src/shared/telegram/poller.test.ts`: `isTransientError` classification table; transient failures are not routed through `onError`; non-transient failures are; updates are delivered and the offset advances.

## How to test

```bash
npm run lint   # passes
npm test       # 75 passed (8 files)
npm run build  # passes
```

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)