### PR TITLE
Fix wrong parameters in VSCode launch file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,7 @@
     {
       "name": "Attach to node",
       "type": "node",
-      "protocol": "inspector",
       "request": "attach",
-      "stopOnEntry": false,
       "restart": true,
       "localRoot": "${workspaceRoot}",
       "remoteRoot": "/usr/src/app",


### PR DESCRIPTION
## Problem

`.vscode/launch.json` showed editor warnings on the `protocol` and `stopOnEntry` properties of the "Attach to node" configuration:

- `protocol`: belonged to the legacy Node debugger. The modern VS Code JavaScript debugger (`js-debug`) only supports the `inspector` protocol and infers it automatically, so the property is no longer recognized.
- `stopOnEntry`: valid for `launch` configurations but not for `attach` ones. Since this config uses `"request": "attach"`, it produced a warning.

Closes #25

## Solution

Removed both obsolete/inapplicable properties from the `attach` configuration. The rest of the config (port `6068`, `restart`, `localRoot`/`remoteRoot`, `sourceMaps`) is unchanged and remains functional.

## How to test

1. Open the project in VS Code.
2. Open `.vscode/launch.json` — no warnings should appear on any property.
3. Run `npm run dev` (starts the inspector on port 6068) and launch the "Attach to node" debug configuration; it attaches as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)