### PR TITLE
Stop using deprecated String.prototype.substr

### DIFF
--- a/src/bot-command.test.ts
+++ b/src/bot-command.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { BotCommand } from "./bot-command";
+import type { Message } from "./shared/telegram/types";
+
+const makeMessage = (text: string): Message =>
+  ({ text }) as unknown as Message;
+
+describe("BotCommand", () => {
+  it("parses a command with no arguments", () => {
+    const cmd = new BotCommand(makeMessage("/wotd"));
+    expect(cmd.label).toBe("wotd");
+    expect(cmd.fullArgs).toBeNull();
+    expect(cmd.args).toEqual([]);
+  });
+
+  it("parses a command with a single argument", () => {
+    const cmd = new BotCommand(makeMessage("/stats 2025-06-01"));
+    expect(cmd.label).toBe("stats");
+    expect(cmd.fullArgs).toBe("2025-06-01");
+    expect(cmd.args).toEqual(["2025-06-01"]);
+  });
+
+  it("parses a command with multiple arguments", () => {
+    const cmd = new BotCommand(makeMessage("/wotd ch extra"));
+    expect(cmd.label).toBe("wotd");
+    expect(cmd.fullArgs).toBe("ch extra");
+    expect(cmd.args).toEqual(["ch", "extra"]);
+  });
+
+  it("lowercases the command label", () => {
+    const cmd = new BotCommand(makeMessage("/WOTD"));
+    expect(cmd.label).toBe("wotd");
+  });
+
+  it("extracts the label correctly when args follow (no off-by-one)", () => {
+    const cmd = new BotCommand(makeMessage("/start hello"));
+    expect(cmd.label).toBe("start");
+    expect(cmd.fullArgs).toBe("hello");
+  });
+
+  it("throws when the message has no text", () => {
+    expect(() => new BotCommand({} as unknown as Message)).toThrow(
+      "Invalid command message",
+    );
+  });
+
+  it("throws when the text does not start with a slash", () => {
+    expect(() => new BotCommand(makeMessage("hello"))).toThrow(
+      "Invalid command message",
+    );
+  });
+});

--- a/src/bot-command.ts
+++ b/src/bot-command.ts
@@ -19,12 +19,12 @@ export class BotCommand {
 
     if (hasArgs) {
       const argsIndex = firstSpaceIndex + 1;
-      this.fullArgs = txt.substr(argsIndex);
+      this.fullArgs = txt.substring(argsIndex);
       this.args = this.fullArgs.split(" ");
     }
 
     this.label = txt
-      .substr(1, hasArgs ? firstSpaceIndex - 1 : undefined)
+      .substring(1, hasArgs ? firstSpaceIndex : undefined)
       .toLowerCase();
     this.message = mess;
   }


### PR DESCRIPTION
## Problem

`String.prototype.substr` is deprecated. The only remaining usages were two calls in `src/bot-command.ts` (`BotCommand` constructor).

## Solution

Replaced both `.substr()` calls with `.substring()`:

- `txt.substr(argsIndex)` → `txt.substring(argsIndex)` (single argument, equivalent).
- `txt.substr(1, hasArgs ? firstSpaceIndex - 1 : undefined)` → `txt.substring(1, hasArgs ? firstSpaceIndex : undefined)`.

Note the semantic difference: `substr(start, length)` takes a **length**, while `substring(start, end)` takes an **end index**. The label-extraction conversion accounts for this (`firstSpaceIndex - 1` length becomes `firstSpaceIndex` end index) so behavior is unchanged — no off-by-one.

Added `src/bot-command.test.ts` with unit tests covering no-args, single-arg, multi-arg, lowercasing, off-by-one label extraction, and the invalid-message error paths, to lock in the parsing semantics.

## How to test

```bash
npm run lint
npm test
npm run build
```

All pass (82 tests, including 7 new `BotCommand` tests).

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)