### PR TITLE
Validate Urban Dictionary API responses with Zod

### DIFF
--- a/src/features/definitions/api.ts
+++ b/src/features/definitions/api.ts
@@ -1,6 +1,7 @@
 import { UdDefinition } from "./definition";
 import { DefinitionCache } from "./cache";
 import { searchTerm } from "./scraper";
+import { udApiResponseSchema } from "./ud-api-schema";
 import { UdApiNotAvailableError } from "../../exceptions/UdApiNotAvailableError";
 import logger from "../../logger";
 
@@ -46,6 +47,9 @@ async function udRequest(method: string, params?: Record<string, string>): Promi
   }
   const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10000) });
   if (!res.ok) throw new Error(`UD API error: ${res.status}`);
-  const data = (await res.json()) as { list?: unknown[] };
-  return (data.list ?? []).map((item) => new UdDefinition(item));
+  const parsed = udApiResponseSchema.safeParse(await res.json());
+  if (!parsed.success) {
+    throw new Error(`UD API returned invalid data: ${parsed.error.message}`);
+  }
+  return parsed.data.list.map((item) => new UdDefinition(item));
 }

--- a/src/features/definitions/ud-api-schema.test.ts
+++ b/src/features/definitions/ud-api-schema.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { udApiResponseSchema, udApiDefinitionSchema } from "./ud-api-schema";
+
+describe("udApiDefinitionSchema", () => {
+  const validItem = {
+    defid: 123,
+    word: "test",
+    definition: "a thing",
+    example: "an example",
+    permalink: "http://urbandictionary.com/define.php?term=test&defid=123",
+    author: "someone",
+  };
+
+  it("accepts a fully populated item", () => {
+    const result = udApiDefinitionSchema.safeParse(validItem);
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults missing optional string fields to empty strings", () => {
+    const result = udApiDefinitionSchema.parse({
+      defid: 1,
+      word: "test",
+      definition: "a thing",
+    });
+    expect(result.example).toBe("");
+    expect(result.permalink).toBe("");
+    expect(result.author).toBe("");
+    expect(result.gif).toBeUndefined();
+  });
+
+  it("ignores unknown extra fields", () => {
+    const result = udApiDefinitionSchema.parse({
+      ...validItem,
+      thumbs_up: 100,
+      written_on: "2020-01-01",
+    });
+    expect(result.word).toBe("test");
+    expect("thumbs_up" in result).toBe(false);
+  });
+
+  it("rejects an item missing required fields", () => {
+    expect(udApiDefinitionSchema.safeParse({ word: "test" }).success).toBe(false);
+  });
+
+  it("rejects an item with a wrong-typed defid", () => {
+    expect(
+      udApiDefinitionSchema.safeParse({ ...validItem, defid: "123" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("udApiResponseSchema", () => {
+  const validItem = {
+    defid: 123,
+    word: "test",
+    definition: "a thing",
+    example: "an example",
+    permalink: "http://urbandictionary.com/define.php",
+    author: "someone",
+  };
+
+  it("parses a valid response with a list of definitions", () => {
+    const result = udApiResponseSchema.parse({ list: [validItem] });
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].word).toBe("test");
+  });
+
+  it("defaults a missing list to an empty array", () => {
+    const result = udApiResponseSchema.parse({});
+    expect(result.list).toEqual([]);
+  });
+
+  it("parses an empty list (no results)", () => {
+    const result = udApiResponseSchema.parse({ list: [] });
+    expect(result.list).toEqual([]);
+  });
+
+  it("rejects corrupt data where list is not an array", () => {
+    expect(udApiResponseSchema.safeParse({ list: "nope" }).success).toBe(false);
+  });
+
+  it("rejects a list containing a structurally broken item", () => {
+    const result = udApiResponseSchema.safeParse({
+      list: [validItem, { not: "a definition" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a null payload", () => {
+    expect(udApiResponseSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/src/features/definitions/ud-api-schema.ts
+++ b/src/features/definitions/ud-api-schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+// Schema for a single definition item as returned by the Urban Dictionary
+// REST API (http://api.urbandictionary.com/v0/ — endpoints `define` / `random`).
+//
+// It is intentionally tolerant: only the fields consumed by `UdDefinition` are
+// described, missing optional fields fall back to sensible defaults, and unknown
+// extra fields are ignored. This lets the bot keep working if the API adds or
+// omits fields, while still rejecting structurally broken payloads.
+export const udApiDefinitionSchema = z.object({
+  defid: z.number(),
+  word: z.string(),
+  definition: z.string(),
+  example: z.string().default(""),
+  permalink: z.string().default(""),
+  author: z.string().default(""),
+  // `gif` is not part of the REST API response (it only comes from the
+  // scraper), but it is kept here as optional so the same shape can be reused.
+  gif: z.string().optional(),
+});
+
+export const udApiResponseSchema = z.object({
+  list: z.array(udApiDefinitionSchema).default([]),
+});
+
+export type UdApiDefinition = z.infer<typeof udApiDefinitionSchema>;
+export type UdApiResponse = z.infer<typeof udApiResponseSchema>;


### PR DESCRIPTION
## Problem

The Urban Dictionary REST API response was cast to a loose type (`{ list?: unknown[] }`) and each item was passed straight into `new UdDefinition(item)` (constructor typed `any`) **without any validation**. A malformed or unexpected payload would silently produce broken definitions instead of being treated as an API failure.

## Solution

- Add `src/features/definitions/ud-api-schema.ts`: a tolerant Zod schema for the API response and each definition item, following the style of `config.ts`.
  - Describes only the fields the bot consumes (`defid`, `word`, `definition`, `example`, `permalink`, `author`, optional `gif`).
  - Optional fields default to sensible values (`""`), and unknown extra fields are ignored, so the bot keeps working if the API adds/omits fields.
  - Structurally broken payloads (missing required fields, wrong types, non-array `list`, `null`) are rejected.
- `udRequest` now validates with `safeParse` before constructing `UdDefinition`s and throws on failure.
- Error behavior is unchanged: in `defineTerm`, a thrown error falls back to the scraper and ultimately raises `UdApiNotAvailableError`; in `random` it propagates. The scraper path and downstream consumers (formatter, templates, keyboards, inline-results, cache) are untouched.

## How to test

```bash
npm run lint   # passes
npm test       # 86 passed (9 files), incl. 11 new schema tests
npm run build  # passes
```

New tests in `src/features/definitions/ud-api-schema.test.ts` cover valid data, missing optional fields, extra fields, and corrupt/empty/null payloads.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)